### PR TITLE
Support for trimming the response body

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ You may override its configuration in your `.env` - the following environment va
 - `HTTP_CLIENT_GLOBAL_LOGGER_RESPONSE_FORMAT` (string)
 - `HTTP_CLIENT_GLOBAL_LOGGER_OBFUSCATE_ENABLED` (bool)
 - `HTTP_CLIENT_GLOBAL_LOGGER_OBFUSCATE_REPLACEMENT` (string)
+- `HTTP_CLIENT_GLOBAL_LOGGER_TRIM_RESPONSE_BODY_ENABLED` (bool)
+- `HTTP_CLIENT_GLOBAL_LOGGER_TRIM_RESPONSE_BODY_TRESHOLD` (int)
+- `HTTP_CLIENT_GLOBAL_LOGGER_TRIM_RESPONSE_BODY_CONTENT_TYPE_WHITELIST` (string)
 
 (look into `config/http-client-global-logger.php` for further configuration and explanation)
 
@@ -45,6 +48,8 @@ Using the logger will log both the request and response of an external HTTP requ
 - Multi-line log records that contain full request/response information (including all headers and body)
 - Logging into separate logfile `http-client.log`. You're free to override this and use your own logging channel or just log to a different logfile.
 - Full support of [Guzzle MessageFormatter](https://github.com/guzzle/guzzle/blob/master/src/MessageFormatter.php) variable substitutions for highly customized log messages.
+- Basic obfuscation of credentials in HTTP Client requests
+- Trimming of response body content to a certain length with support for Content-Type whitelisting
 - **Variant 1: Global logging** (default)
   - Zero-configuration: Global logging is enabled by default in this package.
   - Simple and performant implementation using `RequestSending` / `ResponseReceived` event listeners
@@ -166,6 +171,7 @@ Both packages provide a different feature set and have those advantages:
   - auto-configured log channel `http-client` to log to a separate `http-client.log` file
   - Full support of [Guzzle MessageFormatter](https://github.com/guzzle/guzzle/blob/master/src/MessageFormatter.php) variable substitutions for highly customized log messages.
   - basic obfuscation of credentials in HTTP Client requests
+  - trimming of response body content
 - [bilfeldt/laravel-http-client-logger](https://github.com/bilfeldt/laravel-http-client-logger)
   - conditional logging using `logWhen($condition)`
   - filtering of logs by HTTP response codes

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ You may override its configuration in your `.env` - the following environment va
 - `HTTP_CLIENT_GLOBAL_LOGGER_OBFUSCATE_ENABLED` (bool)
 - `HTTP_CLIENT_GLOBAL_LOGGER_OBFUSCATE_REPLACEMENT` (string)
 - `HTTP_CLIENT_GLOBAL_LOGGER_TRIM_RESPONSE_BODY_ENABLED` (bool)
-- `HTTP_CLIENT_GLOBAL_LOGGER_TRIM_RESPONSE_BODY_TRESHOLD` (int)
+- `HTTP_CLIENT_GLOBAL_LOGGER_TRIM_RESPONSE_BODY_LIMIT` (int)
 - `HTTP_CLIENT_GLOBAL_LOGGER_TRIM_RESPONSE_BODY_CONTENT_TYPE_WHITELIST` (string)
 
-(look into `config/http-client-global-logger.php` for further configuration and explanation)
+(look into `config/http-client-global-logger.php` for defaults, further configuration, and explanation)
 
 ## Features
 

--- a/config/http-client-global-logger.php
+++ b/config/http-client-global-logger.php
@@ -121,7 +121,7 @@ return [
     */
     'trim_response_body' => [
         'enabled' => env('HTTP_CLIENT_GLOBAL_LOGGER_TRIM_RESPONSE_BODY_ENABLED', false),
-        'treshold' => env('HTTP_CLIENT_GLOBAL_LOGGER_TRIM_RESPONSE_BODY_TRESHOLD', 200),
+        'limit' => env('HTTP_CLIENT_GLOBAL_LOGGER_TRIM_RESPONSE_BODY_LIMIT', 200),
         'content_type_whitelist' => explode(',', env(
             'HTTP_CLIENT_GLOBAL_LOGGER_TRIM_RESPONSE_BODY_CONTENT_TYPE_WHITELIST',
             ',application/json'

--- a/config/http-client-global-logger.php
+++ b/config/http-client-global-logger.php
@@ -114,14 +114,17 @@ return [
     |--------------------------------------------------------------------------
     |
     | Trim response body to a certain length. This is useful when you are logging
-    | large responses and you don't want to fill up your log files.
+    | large responses, and you don't want to fill up your log files.
+    |
+    | NOTE the leading comma in trim_response_body.content_type_whitelist default value:
+    | it's there to whitelist empty content types (e.g. when no Content-Type header is set).
     */
     'trim_response_body' => [
         'enabled' => env('HTTP_CLIENT_GLOBAL_LOGGER_TRIM_RESPONSE_BODY_ENABLED', false),
         'treshold' => env('HTTP_CLIENT_GLOBAL_LOGGER_TRIM_RESPONSE_BODY_TRESHOLD', 200),
         'content_type_whitelist' => explode(',', env(
             'HTTP_CLIENT_GLOBAL_LOGGER_TRIM_RESPONSE_BODY_CONTENT_TYPE_WHITELIST',
-            'application/json'
+            ',application/json'
         )),
     ],
 ];

--- a/config/http-client-global-logger.php
+++ b/config/http-client-global-logger.php
@@ -107,4 +107,21 @@ return [
             'pass,password,token,apikey,access_token,refresh_token,client_secret'
         )),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Trim response body
+    |--------------------------------------------------------------------------
+    |
+    | Trim response body to a certain length. This is useful when you are logging
+    | large responses and you don't want to fill up your log files.
+    */
+    'trim_response_body' => [
+        'enabled' => env('HTTP_CLIENT_GLOBAL_LOGGER_TRIM_RESPONSE_BODY_ENABLED', false),
+        'treshold' => env('HTTP_CLIENT_GLOBAL_LOGGER_TRIM_RESPONSE_BODY_TRESHOLD', 200),
+        'content_type_whitelist' => explode(',', env(
+            'HTTP_CLIENT_GLOBAL_LOGGER_TRIM_RESPONSE_BODY_CONTENT_TYPE_WHITELIST',
+            'application/json'
+        )),
+    ],
 ];

--- a/src/Listeners/LogResponseReceived.php
+++ b/src/Listeners/LogResponseReceived.php
@@ -4,7 +4,7 @@ namespace Onlime\LaravelHttpClientGlobalLogger\Listeners;
 
 use GuzzleHttp\MessageFormatter;
 use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Psr7\Stream;
+use GuzzleHttp\Psr7\Utils;
 use Illuminate\Http\Client\Events\ResponseReceived;
 use Illuminate\Support\Facades\Log;
 use Onlime\LaravelHttpClientGlobalLogger\EventHelper;
@@ -55,10 +55,8 @@ class LogResponseReceived
             return $psrResponse;
         }
 
-        $resource = \fopen('php://memory', 'r+');
-        \fwrite($resource, substr($psrResponse->getBody()->__toString(), 0, $treshold).'...');
-        \fseek($resource, 0);
-
-        return $psrResponse->withBody(new Stream($resource));
+        return $psrResponse->withBody(Utils::streamFor(
+            substr($psrResponse->getBody(), 0, $treshold).'...'
+        ));
     }
 }

--- a/src/Listeners/LogResponseReceived.php
+++ b/src/Listeners/LogResponseReceived.php
@@ -38,20 +38,19 @@ class LogResponseReceived
             return $psrResponse;
         }
 
-        $trimAndLower = fn (string $type) => trim(strtolower($type));
+        $treshold = config('http-client-global-logger.trim_response_body.treshold');
 
+        // Check if the body size exceeds the treshold
+        if ($psrResponse->getBody()->getSize() <= $treshold) {
+            return $psrResponse;
+        }
+
+        $trimAndLower = fn (string $type) => trim(strtolower($type));
         $responseContentTypes = array_map($trimAndLower, $psrResponse->getHeader('Content-Type'));
         $whiteListedContentTypes = array_map($trimAndLower, config('http-client-global-logger.trim_response_body.content_type_whitelist'));
 
         // Check if the content type is whitelisted
         if (count(array_intersect($responseContentTypes, $whiteListedContentTypes)) > 0) {
-            return $psrResponse;
-        }
-
-        $treshold = config('http-client-global-logger.trim_response_body.treshold');
-
-        // Check if the body size exceeds the treshold
-        if ($psrResponse->getBody()->getSize() <= $treshold) {
             return $psrResponse;
         }
 

--- a/src/Listeners/LogResponseReceived.php
+++ b/src/Listeners/LogResponseReceived.php
@@ -3,6 +3,8 @@
 namespace Onlime\LaravelHttpClientGlobalLogger\Listeners;
 
 use GuzzleHttp\MessageFormatter;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Stream;
 use Illuminate\Http\Client\Events\ResponseReceived;
 use Illuminate\Support\Facades\Log;
 use Onlime\LaravelHttpClientGlobalLogger\EventHelper;
@@ -22,7 +24,41 @@ class LogResponseReceived
         $formatter = new MessageFormatter(config('http-client-global-logger.format.response'));
         Log::channel(config('http-client-global-logger.channel'))->info($formatter->format(
             EventHelper::getPsrRequest($event),
-            EventHelper::getPsrResponse($event),
+            $this->trimBody(EventHelper::getPsrResponse($event))
         ));
+    }
+
+    /**
+     * Trim the response body when it's too long.
+     */
+    private function trimBody(Response $psrResponse): Response
+    {
+        // Check if trimming is enabled
+        if (! config('http-client-global-logger.trim_response_body.enabled')) {
+            return $psrResponse;
+        }
+
+        $trimAndLower = fn (string $type) => trim(strtolower($type));
+
+        $responseContentTypes = array_map($trimAndLower, $psrResponse->getHeader('Content-Type'));
+        $whiteListedContentTypes = array_map($trimAndLower, config('http-client-global-logger.trim_response_body.content_type_whitelist'));
+
+        // Check if the content type is whitelisted
+        if (count(array_intersect($responseContentTypes, $whiteListedContentTypes)) > 0) {
+            return $psrResponse;
+        }
+
+        $treshold = config('http-client-global-logger.trim_response_body.treshold');
+
+        // Check if the body size exceeds the treshold
+        if ($psrResponse->getBody()->getSize() <= $treshold) {
+            return $psrResponse;
+        }
+
+        $resource = \fopen('php://memory', 'r+');
+        \fwrite($resource, substr($psrResponse->getBody()->__toString(), 0, $treshold).'...');
+        \fseek($resource, 0);
+
+        return $psrResponse->withBody(new Stream($resource));
     }
 }

--- a/src/Listeners/LogResponseReceived.php
+++ b/src/Listeners/LogResponseReceived.php
@@ -57,13 +57,13 @@ class LogResponseReceived
             return $psrResponse;
         }
 
-        $treshold = config('http-client-global-logger.trim_response_body.treshold');
+        $limit = config('http-client-global-logger.trim_response_body.limit');
 
-        // Check if the body size exceeds the treshold
-        return ($psrResponse->getBody()->getSize() <= $treshold)
+        // Check if the body size exceeds the limit
+        return ($psrResponse->getBody()->getSize() <= $limit)
             ? $psrResponse
             : $psrResponse->withBody(Utils::streamFor(
-                Str::limit($psrResponse->getBody(), $treshold)
+                Str::limit($psrResponse->getBody(), $limit)
             ));
     }
 }

--- a/src/Listeners/LogResponseReceived.php
+++ b/src/Listeners/LogResponseReceived.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Utils;
 use Illuminate\Http\Client\Events\ResponseReceived;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 use Onlime\LaravelHttpClientGlobalLogger\EventHelper;
 use Saloon\Laravel\Events\SentSaloonRequest;
 
@@ -55,7 +56,7 @@ class LogResponseReceived
         }
 
         return $psrResponse->withBody(Utils::streamFor(
-            substr($psrResponse->getBody(), 0, $treshold).'...'
+            Str::limit($psrResponse->getBody(), $treshold)
         ));
     }
 }

--- a/tests/HttpClientLoggerTest.php
+++ b/tests/HttpClientLoggerTest.php
@@ -44,7 +44,7 @@ it('can add a global request middleware to log the requests', function () {
     Http::fake()->get('https://example.com');
 });
 
-it('can trim the body response', function (array $config, bool $shouldTrim, bool $addCharsetToContentType) {
+it('can trim the body response', function (array $config, string $contentType, bool $shouldTrim, bool $addCharsetToContentType) {
     config(['http-client-global-logger.trim_response_body' => $config]);
 
     $logger = setupLogger();
@@ -61,7 +61,7 @@ it('can trim the body response', function (array $config, bool $shouldTrim, bool
 
     Http::fake([
         '*' => Http::response('verylongbody', 200, [
-            'content-type' => 'application/octet-stream'.($addCharsetToContentType ? '; charset=UTF-8' : ''),
+            'Content-Type' => $contentType.($addCharsetToContentType ? '; charset=UTF-8' : ''),
         ]),
     ])->get('https://example.com');
 })->with(
@@ -72,6 +72,7 @@ it('can trim the body response', function (array $config, bool $shouldTrim, bool
                 'treshold' => 10,
                 'content_type_whitelist' => ['application/json'],
             ],
+            'contentType' => 'application/octet-stream',
             'shouldTrim' => false,
         ],
         'below_treshold' => [
@@ -80,6 +81,7 @@ it('can trim the body response', function (array $config, bool $shouldTrim, bool
                 'treshold' => 20,
                 'content_type_whitelist' => ['application/json'],
             ],
+            'contentType' => 'application/octet-stream',
             'shouldTrim' => false,
         ],
         'content_type_whitelisted' => [
@@ -88,6 +90,7 @@ it('can trim the body response', function (array $config, bool $shouldTrim, bool
                 'treshold' => 10,
                 'content_type_whitelist' => ['application/octet-stream'],
             ],
+            'contentType' => 'application/octet-stream',
             'shouldTrim' => false,
         ],
         'trim' => [
@@ -96,7 +99,26 @@ it('can trim the body response', function (array $config, bool $shouldTrim, bool
                 'treshold' => 10,
                 'content_type_whitelist' => ['application/json'],
             ],
+            'contentType' => 'application/octet-stream',
             'shouldTrim' => true,
+        ],
+        'no_content_type_trim' => [
+            'config' => [
+                'enabled' => true,
+                'treshold' => 10,
+                'content_type_whitelist' => ['application/octet-stream'],
+            ],
+            'contentType' => '',
+            'shouldTrim' => true,
+        ],
+        'no_content_type_whitelisted' => [
+            'config' => [
+                'enabled' => true,
+                'treshold' => 10,
+                'content_type_whitelist' => ['', 'application/octet-stream'],
+            ],
+            'contentType' => '',
+            'shouldTrim' => false,
         ],
     ],
     [true, false]

--- a/tests/HttpClientLoggerTest.php
+++ b/tests/HttpClientLoggerTest.php
@@ -69,16 +69,16 @@ it('can trim the body response', function (array $config, string $contentType, b
         'disabled' =>  [
             'config' => [
                 'enabled' => false,
-                'treshold' => 10,
+                'limit' => 10,
                 'content_type_whitelist' => ['application/json'],
             ],
             'contentType' => 'application/octet-stream',
             'shouldTrim' => false,
         ],
-        'below_treshold' => [
+        'below_limit' => [
             'config' => [
                 'enabled' => true,
-                'treshold' => 20,
+                'limit' => 20,
                 'content_type_whitelist' => ['application/json'],
             ],
             'contentType' => 'application/octet-stream',
@@ -87,7 +87,7 @@ it('can trim the body response', function (array $config, string $contentType, b
         'content_type_whitelisted' => [
             'config' => [
                 'enabled' => true,
-                'treshold' => 10,
+                'limit' => 10,
                 'content_type_whitelist' => ['application/octet-stream'],
             ],
             'contentType' => 'application/octet-stream',
@@ -96,7 +96,7 @@ it('can trim the body response', function (array $config, string $contentType, b
         'trim' => [
             'config' => [
                 'enabled' => true,
-                'treshold' => 10,
+                'limit' => 10,
                 'content_type_whitelist' => ['application/json'],
             ],
             'contentType' => 'application/octet-stream',
@@ -105,7 +105,7 @@ it('can trim the body response', function (array $config, string $contentType, b
         'no_content_type_trim' => [
             'config' => [
                 'enabled' => true,
-                'treshold' => 10,
+                'limit' => 10,
                 'content_type_whitelist' => ['application/octet-stream'],
             ],
             'contentType' => '',
@@ -114,7 +114,7 @@ it('can trim the body response', function (array $config, string $contentType, b
         'no_content_type_whitelisted' => [
             'config' => [
                 'enabled' => true,
-                'treshold' => 10,
+                'limit' => 10,
                 'content_type_whitelist' => ['', 'application/octet-stream'],
             ],
             'contentType' => '',

--- a/tests/HttpClientLoggerTest.php
+++ b/tests/HttpClientLoggerTest.php
@@ -44,7 +44,7 @@ it('can add a global request middleware to log the requests', function () {
     Http::fake()->get('https://example.com');
 });
 
-it('can trim the body response', function (array $config, bool $shouldTrim) {
+it('can trim the body response', function (array $config, bool $shouldTrim, bool $addCharsetToContentType) {
     config(['http-client-global-logger.trim_response_body' => $config]);
 
     $logger = setupLogger();
@@ -60,7 +60,9 @@ it('can trim the body response', function (array $config, bool $shouldTrim) {
     })->once();
 
     Http::fake([
-        '*' => Http::response('verylongbody', 200, ['content-type' => 'application/octet-stream']),
+        '*' => Http::response('verylongbody', 200, [
+            'content-type' => 'application/octet-stream'.($addCharsetToContentType ? '; charset=UTF-8' : ''),
+        ]),
     ])->get('https://example.com');
 })->with(
     [
@@ -96,5 +98,6 @@ it('can trim the body response', function (array $config, bool $shouldTrim) {
             ],
             'shouldTrim' => true,
         ],
-    ]
+    ],
+    [true, false]
 );


### PR DESCRIPTION
This PR adds support for trimming the response body. You may configure it with the following options:

* Enable/disable
* Size treshold
* Content-type whitelist

To avoid any breaking change, the trimming is disabled by default.