### PR TITLE
Add URL exclusion patterns via `except` config option / bumped saloonphp/laravel-plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,16 +54,6 @@ jobs:
             "orchestra/testbench:${{ matrix.testbench }}" \
             --dev --no-interaction --no-update
 
-          # saloonphp/laravel-plugin does not yet have a stable release for Laravel 13
-          # Use laravel-shift fork branch with inline alias to satisfy ^3.9 and minimum-stability:stable
-          # see https://github.com/saloonphp/laravel-plugin/pull/77
-          if [[ "${{ matrix.laravel }}" == "13.*" ]]; then
-            composer config repositories.saloon-laravel-plugin vcs https://github.com/laravel-shift/laravel-plugin.git
-            composer require \
-              "saloonphp/laravel-plugin:dev-l13-compatibility as 3.9.2" \
-              --dev --no-interaction --no-update
-          fi
-
           composer update \
             --${{ matrix.stability }} \
             --prefer-dist --no-interaction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # CHANGELOG
 
-## [v1.3.x (Unreleased)](https://github.com/onlime/laravel-http-client-global-logger/compare/v1.3.1...main)
+## [v1.4.x (Unreleased)](https://github.com/onlime/laravel-http-client-global-logger/compare/v1.4.0...main)
 
-## [v1.3.1 (2026-04-20)](https://github.com/onlime/laravel-http-client-global-logger/compare/v1.3.0...v1.3.1)
+## [v1.4.0 (2026-04-20)](https://github.com/onlime/laravel-http-client-global-logger/compare/v1.3.0...v1.4.0)
 
 - Feature | URL exclusion patterns via `HTTP_CLIENT_GLOBAL_LOGGER_EXCEPT` env var. Comma-separated wildcard patterns (using `Str::is()`) to skip logging for specific URLs, e.g. `https://api.pirsch.io/*,https://sentry.io/*`.
+- Bumped `saloonphp/laravel-plugin` to `^4.1`, removed `laravel-shift/laravel-plugin` fork workaround from CI.
 
 ## [v1.3.0 (2026-03-18)](https://github.com/onlime/laravel-http-client-global-logger/compare/v1.2.8...v1.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
-## [v1.3.x (Unreleased)](https://github.com/onlime/laravel-http-client-global-logger/compare/v1.3.0...main)
+## [v1.3.x (Unreleased)](https://github.com/onlime/laravel-http-client-global-logger/compare/v1.3.1...main)
+
+## [v1.3.1 (2026-04-20)](https://github.com/onlime/laravel-http-client-global-logger/compare/v1.3.0...v1.3.1)
+
+- Feature | URL exclusion patterns via `HTTP_CLIENT_GLOBAL_LOGGER_EXCEPT` env var. Comma-separated wildcard patterns (using `Str::is()`) to skip logging for specific URLs, e.g. `https://api.pirsch.io/*,https://sentry.io/*`.
 
 ## [v1.3.0 (2026-03-18)](https://github.com/onlime/laravel-http-client-global-logger/compare/v1.2.8...v1.3.0)
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You may override its configuration in your `.env` - the following environment va
 - `HTTP_CLIENT_GLOBAL_LOGGER_LOGFILE` (string)
 - `HTTP_CLIENT_GLOBAL_LOGGER_REQUEST_FORMAT` (string)
 - `HTTP_CLIENT_GLOBAL_LOGGER_RESPONSE_FORMAT` (string)
+- `HTTP_CLIENT_GLOBAL_LOGGER_EXCEPT` (string, comma-separated URL patterns with wildcard support)
 - `HTTP_CLIENT_GLOBAL_LOGGER_OBFUSCATE_ENABLED` (bool)
 - `HTTP_CLIENT_GLOBAL_LOGGER_OBFUSCATE_REPLACEMENT` (string)
 - `HTTP_CLIENT_GLOBAL_LOGGER_TRIM_RESPONSE_BODY_ENABLED` (bool)
@@ -50,6 +51,7 @@ Using the logger will log both the request and response of an external HTTP requ
 - Logging into separate logfile `http-client.log`. You're free to override this and use your own logging channel or just log to a different logfile.
 - Full support of [Guzzle MessageFormatter](https://github.com/guzzle/guzzle/blob/master/src/MessageFormatter.php) variable substitutions for highly customized log messages.
 - Basic obfuscation of credentials in HTTP Client requests (both by header or body keys)
+- URL exclusion patterns to skip logging for specific URLs (e.g. `HTTP_CLIENT_GLOBAL_LOGGER_EXCEPT=https://api.pirsch.io/*,https://sentry.io/*`)
 - Trimming of response body content to a certain length with support for `Content-Type` whitelisting
 - Enforce trimming of response body content by setting a `X-Global-Logger-Trim-Always` request header, which will ignore the whitelisting.
 - **Variant 1: Global logging** (default)

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "pestphp/pest": "^3.8 || ^4.1",
         "pestphp/pest-plugin-arch": "^3.1 || ^4.0",
         "pestphp/pest-plugin-laravel": "^3.2 || ^4.0",
-        "saloonphp/laravel-plugin": "^3.9",
+        "saloonphp/laravel-plugin": "^4.1",
         "spatie/invade": "^2.1"
     },
     "suggest": {

--- a/config/http-client-global-logger.php
+++ b/config/http-client-global-logger.php
@@ -50,6 +50,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Except URL patterns
+    |--------------------------------------------------------------------------
+    |
+    | URLs matching any of these patterns will not be logged. Supports wildcard
+    | patterns using '*' (e.g. 'https://api.pirsch.io/*'). Matching is done
+    | using Illuminate\Support\Str::is().
+    |
+    */
+    'except' => array_filter(explode(',', env('HTTP_CLIENT_GLOBAL_LOGGER_EXCEPT', ''))),
+
+    /*
+    |--------------------------------------------------------------------------
     | Log message formats
     |--------------------------------------------------------------------------
     |

--- a/src/HttpClientLogger.php
+++ b/src/HttpClientLogger.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Client\Events\RequestSending;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Onlime\LaravelHttpClientGlobalLogger\Listeners\LogRequestSending;
+use Onlime\LaravelHttpClientGlobalLogger\Support\UrlFilter;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -24,6 +25,10 @@ class HttpClientLogger
 
         Http::globalRequestMiddleware(
             fn (RequestInterface $psrRequest) => tap($psrRequest, function (RequestInterface $psrRequest) {
+                if (! UrlFilter::shouldLog($psrRequest)) {
+                    return;
+                }
+
                 // Wrap PSR-7 request into Laravel's HTTP Client Request object
                 $clientRequest = new Request($psrRequest);
 

--- a/src/Listeners/LogRequestSending.php
+++ b/src/Listeners/LogRequestSending.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Client\Events\RequestSending;
 use Illuminate\Support\Facades\Log;
 use Onlime\LaravelHttpClientGlobalLogger\EventHelper;
 use Onlime\LaravelHttpClientGlobalLogger\HttpClientLogger;
+use Onlime\LaravelHttpClientGlobalLogger\Support\UrlFilter;
 use Onlime\LaravelHttpClientGlobalLogger\Traits\ObfuscatesBody;
 use Psr\Http\Message\RequestInterface;
 use Saloon\Laravel\Events\SendingSaloonRequest;
@@ -36,6 +37,10 @@ class LogRequestSending
     public function handleEvent(RequestSending|SendingSaloonRequest $event): void
     {
         $psrRequest = EventHelper::getPsrRequest($event);
+
+        if (! UrlFilter::shouldLog($psrRequest)) {
+            return;
+        }
 
         $obfuscate  = config('http-client-global-logger.obfuscate.enabled');
 

--- a/src/Listeners/LogResponseReceived.php
+++ b/src/Listeners/LogResponseReceived.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Client\Events\ResponseReceived;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Onlime\LaravelHttpClientGlobalLogger\EventHelper;
+use Onlime\LaravelHttpClientGlobalLogger\Support\UrlFilter;
 use Onlime\LaravelHttpClientGlobalLogger\Traits\ObfuscatesBody;
 use Psr\Http\Message\MessageInterface;
 use Saloon\Laravel\Events\SentSaloonRequest;
@@ -24,8 +25,13 @@ class LogResponseReceived
      */
     public function handle(ResponseReceived|SentSaloonRequest $event): void
     {
-        $formatter = new MessageFormatter(config('http-client-global-logger.format.response'));
         $psrRequest = EventHelper::getPsrRequest($event);
+
+        if (! UrlFilter::shouldLog($psrRequest)) {
+            return;
+        }
+
+        $formatter = new MessageFormatter(config('http-client-global-logger.format.response'));
 
         $message = $formatter->format(
             $psrRequest,

--- a/src/Support/UrlFilter.php
+++ b/src/Support/UrlFilter.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Onlime\LaravelHttpClientGlobalLogger\Support;
+
+use Illuminate\Support\Str;
+use Psr\Http\Message\RequestInterface;
+
+class UrlFilter
+{
+    public static function shouldLog(RequestInterface $request): bool
+    {
+        $url = (string) $request->getUri();
+        $patterns = config('http-client-global-logger.except', []);
+
+        if (empty($patterns)) {
+            return true;
+        }
+
+        return ! Str::is($patterns, $url);
+    }
+}

--- a/tests/HttpClientLoggerTest.php
+++ b/tests/HttpClientLoggerTest.php
@@ -227,6 +227,47 @@ it('obfuscates request uri via body obfuscation', function (string $uri, string 
     ],
 ]);
 
+it('excludes URLs matching except patterns', function () {
+    config(['http-client-global-logger.except' => ['https://api.pirsch.io/*']]);
+
+    $logger = setupLogger();
+
+    $logger->shouldNotReceive('info');
+
+    Http::fake()->get('https://api.pirsch.io/api/v1/hit');
+});
+
+it('logs URLs not matching except patterns', function () {
+    config(['http-client-global-logger.except' => ['https://api.pirsch.io/*']]);
+
+    $logger = setupLogger();
+
+    $logger->shouldReceive('info')->withArgs(function ($message) {
+        expect($message)->toContain('REQUEST: GET https://example.com');
+        return true;
+    })->once();
+
+    $logger->shouldReceive('info')->withArgs(function ($message) {
+        expect($message)->toContain('RESPONSE: HTTP/1.1 200 OK');
+        return true;
+    })->once();
+
+    Http::fake()->get('https://example.com');
+});
+
+it('supports multiple except patterns', function () {
+    config(['http-client-global-logger.except' => [
+        'https://api.pirsch.io/*',
+        'https://sentry.io/*',
+    ]]);
+
+    $logger = setupLogger();
+
+    $logger->shouldNotReceive('info');
+
+    Http::fake()->get('https://sentry.io/api/0/envelope');
+});
+
 it('obfuscates response body', function (string $body, string $expected) {
     $logger = setupLogger();
 


### PR DESCRIPTION
- Feature | URL exclusion patterns via `HTTP_CLIENT_GLOBAL_LOGGER_EXCEPT` env var. Comma-separated wildcard patterns (using `Str::is()`) to skip logging for specific URLs, e.g. `https://api.pirsch.io/*,https://sentry.io/*`.
- Bumped `saloonphp/laravel-plugin` to `^4.1`, removed `laravel-shift/laravel-plugin` fork workaround from CI.