### PR TITLE
Combined request/response logging (single record per call, default on)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [v1.4.x (Unreleased)](https://github.com/onlime/laravel-http-client-global-logger/compare/v1.4.0...main)
 
+- Feature | Combined request/response logging via `HTTP_CLIENT_GLOBAL_LOGGER_COMBINED` (default `true`). Each call is now logged as a single atomic record (request + response together) instead of two separate records, so concurrent calls can no longer interleave their request/response halves in the logfile. The individual `REQUEST:` / `RESPONSE:` block format is unchanged. Set to `false` to restore the legacy two-record behaviour.
+
 ## [v1.4.0 (2026-04-20)](https://github.com/onlime/laravel-http-client-global-logger/compare/v1.3.0...v1.4.0)
 
 - Feature | URL exclusion patterns via `HTTP_CLIENT_GLOBAL_LOGGER_EXCEPT` env var. Comma-separated wildcard patterns (using `Str::is()`) to skip logging for specific URLs, e.g. `https://api.pirsch.io/*,https://sentry.io/*`.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Using the logger will log both the request and response of an external HTTP requ
 - URL exclusion patterns to skip logging for specific URLs (e.g. `HTTP_CLIENT_GLOBAL_LOGGER_EXCEPT=https://api.pirsch.io/*,https://sentry.io/*`)
 - Trimming of response body content to a certain length with support for `Content-Type` whitelisting
 - Enforce trimming of response body content by setting a `X-Global-Logger-Trim-Always` request header, which will ignore the whitelisting.
+- **Combined request/response logging** (default, `HTTP_CLIENT_GLOBAL_LOGGER_COMBINED=true`): each call is logged as a single atomic record — the request and response together — instead of two separate records. The `REQUEST:` / `RESPONSE:` blocks keep their exact same format; they're just emitted as one log record. This matters under concurrency: when multiple workers/processes share the logfile (or requests are pooled/async), two separate records interleave with other calls' records and — sharing no correlation id — can no longer be matched back to each other. Set to `false` to restore the legacy two-record behaviour.
 - **Variant 1: Global logging** (default)
   - Zero-configuration: Global logging is enabled by default in this package.
   - Simple and performant implementation using `RequestSending` / `ResponseReceived` event listeners

--- a/config/http-client-global-logger.php
+++ b/config/http-client-global-logger.php
@@ -28,6 +28,23 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Combined request/response logging
+    |--------------------------------------------------------------------------
+    |
+    | Log each call as a SINGLE entry (request + response together, emitted when
+    | the response arrives) instead of two separate entries. This is the default:
+    | with two separate entries, concurrent calls — multiple workers/processes
+    | sharing the channel, or pooled/async requests — interleave their REQUEST and
+    | RESPONSE lines in the log and, sharing no correlation id, can no longer be
+    | matched back to each other. The REQUEST/RESPONSE blocks keep their exact same
+    | format; they're just emitted as one log record. Set this to false to restore
+    | the legacy two-entry behaviour.
+    |
+    */
+    'combined' => (bool) env('HTTP_CLIENT_GLOBAL_LOGGER_COMBINED', true),
+
+    /*
+    |--------------------------------------------------------------------------
     | Log to channel
     |--------------------------------------------------------------------------
     |

--- a/src/Listeners/LogRequestSending.php
+++ b/src/Listeners/LogRequestSending.php
@@ -11,12 +11,13 @@ use Onlime\LaravelHttpClientGlobalLogger\EventHelper;
 use Onlime\LaravelHttpClientGlobalLogger\HttpClientLogger;
 use Onlime\LaravelHttpClientGlobalLogger\Support\UrlFilter;
 use Onlime\LaravelHttpClientGlobalLogger\Traits\ObfuscatesBody;
-use Psr\Http\Message\RequestInterface;
+use Onlime\LaravelHttpClientGlobalLogger\Traits\ObfuscatesHeaders;
 use Saloon\Laravel\Events\SendingSaloonRequest;
 
 class LogRequestSending
 {
     use ObfuscatesBody;
+    use ObfuscatesHeaders;
 
     /**
      * Handle the event if the HTTP Client global request middleware was not added manually
@@ -36,13 +37,19 @@ class LogRequestSending
      */
     public function handleEvent(RequestSending|SendingSaloonRequest $event): void
     {
+        // In combined mode the request is logged together with the response by
+        // LogResponseReceived, so there is no separate request entry to write here.
+        if (config('http-client-global-logger.combined')) {
+            return;
+        }
+
         $psrRequest = EventHelper::getPsrRequest($event);
 
         if (! UrlFilter::shouldLog($psrRequest)) {
             return;
         }
 
-        $obfuscate  = config('http-client-global-logger.obfuscate.enabled');
+        $obfuscate = config('http-client-global-logger.obfuscate.enabled');
 
         if ($obfuscate) {
             $psrRequest = $this->obfuscateHeaders($psrRequest);
@@ -57,28 +64,5 @@ class LogRequestSending
 
         Log::channel(config('http-client-global-logger.channel'))
             ->info($message);
-    }
-
-    /**
-     * Obfuscate headers, e.g. Authorization header.
-     */
-    protected function obfuscateHeaders(RequestInterface $request): RequestInterface
-    {
-        $replacement = config('http-client-global-logger.obfuscate.replacement');
-
-        // TODO: Currently, there is no clean way of modifying the PendingRequest body, e.g. via Macros
-        // see https://stackoverflow.com/q/60603066/5982842
-        // Tried to modify data directly on HTTP Client Request object, but PsrRequest is already set
-        // $data = $request->data();
-        // data_set($data, 'params.pass', $replacement);
-        // $request = $request->withData($data);
-
-        foreach (config('http-client-global-logger.obfuscate.headers') as $name) {
-            if ($request->hasHeader($name)) {
-                $request = $request->withHeader($name, $replacement);
-            }
-        }
-
-        return $request;
     }
 }

--- a/src/Listeners/LogResponseReceived.php
+++ b/src/Listeners/LogResponseReceived.php
@@ -13,12 +13,14 @@ use Illuminate\Support\Str;
 use Onlime\LaravelHttpClientGlobalLogger\EventHelper;
 use Onlime\LaravelHttpClientGlobalLogger\Support\UrlFilter;
 use Onlime\LaravelHttpClientGlobalLogger\Traits\ObfuscatesBody;
+use Onlime\LaravelHttpClientGlobalLogger\Traits\ObfuscatesHeaders;
 use Psr\Http\Message\MessageInterface;
 use Saloon\Laravel\Events\SentSaloonRequest;
 
 class LogResponseReceived
 {
     use ObfuscatesBody;
+    use ObfuscatesHeaders;
 
     /**
      * Handle the event.
@@ -31,9 +33,9 @@ class LogResponseReceived
             return;
         }
 
-        $formatter = new MessageFormatter(config('http-client-global-logger.format.response'));
+        $obfuscate = config('http-client-global-logger.obfuscate.enabled');
 
-        $message = $formatter->format(
+        $message = (new MessageFormatter(config('http-client-global-logger.format.response')))->format(
             $psrRequest,
             $this->trimBody(
                 EventHelper::getPsrResponse($event),
@@ -41,7 +43,15 @@ class LogResponseReceived
             )
         );
 
-        if (config('http-client-global-logger.obfuscate.enabled')) {
+        // Combined mode: prepend the request so the whole call is a single atomic entry
+        // (no separate request entry is written by LogRequestSending in this mode).
+        if (config('http-client-global-logger.combined')) {
+            $request = $obfuscate ? $this->obfuscateHeaders($psrRequest) : $psrRequest;
+            $requestMessage = (new MessageFormatter(config('http-client-global-logger.format.request')))->format($request);
+            $message = $requestMessage."\n".$message;
+        }
+
+        if ($obfuscate) {
             $message = $this->obfuscateBody($message);
         }
 

--- a/src/Traits/ObfuscatesHeaders.php
+++ b/src/Traits/ObfuscatesHeaders.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Onlime\LaravelHttpClientGlobalLogger\Traits;
+
+use Psr\Http\Message\RequestInterface;
+
+trait ObfuscatesHeaders
+{
+    /**
+     * Obfuscate configured request headers, e.g. the Authorization header.
+     */
+    protected function obfuscateHeaders(RequestInterface $request): RequestInterface
+    {
+        $replacement = config('http-client-global-logger.obfuscate.replacement');
+
+        foreach (config('http-client-global-logger.obfuscate.headers') as $name) {
+            if ($request->hasHeader($name)) {
+                $request = $request->withHeader($name, $replacement);
+            }
+        }
+
+        return $request;
+    }
+}

--- a/tests/CombinedLoggingTest.php
+++ b/tests/CombinedLoggingTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Psr\Log\LoggerInterface;
+
+it('logs the request and response as a single combined entry by default', function () {
+    $logger = Mockery::mock(LoggerInterface::class);
+    Log::shouldReceive('channel')->with('http-client')->andReturn($logger);
+
+    // A single log record containing BOTH the request and the response — no separate
+    // REQUEST entry, so concurrent calls can never interleave their two halves.
+    $logger->shouldReceive('info')->withArgs(function ($message) {
+        expect($message)
+            ->toContain('REQUEST: GET https://example.com')
+            ->and($message)->toContain('RESPONSE: HTTP/1.1 200 OK');
+
+        return true;
+    })->once()->andReturnSelf();
+
+    Http::fake()->get('https://example.com');
+});
+
+it('keeps the individual REQUEST/RESPONSE format inside the combined entry', function () {
+    $logger = Mockery::mock(LoggerInterface::class);
+    Log::shouldReceive('channel')->with('http-client')->andReturn($logger);
+
+    $logger->shouldReceive('info')->withArgs(function ($message) {
+        // The request block comes first, the response block second — each unchanged.
+        expect(strpos($message, 'REQUEST: POST https://example.com'))->toBe(0)
+            ->and($message)->toContain("Authorization: **********\r\n")
+            ->and(strpos($message, 'RESPONSE: HTTP/1.1 200 OK'))
+            ->toBeGreaterThan(strpos($message, 'REQUEST:'));
+
+        return true;
+    })->once()->andReturnSelf();
+
+    Http::fake([
+        '*' => Http::response('', 200, ['Content-Type' => 'application/json']),
+    ])->withHeader('Authorization', 'Bearer 123')->post('https://example.com');
+});
+
+it('logs two separate entries when combined is disabled', function () {
+    config(['http-client-global-logger.combined' => false]);
+
+    $logger = Mockery::mock(LoggerInterface::class);
+    Log::shouldReceive('channel')->with('http-client')->andReturn($logger);
+
+    $logger->shouldReceive('info')
+        ->withArgs(fn ($message) => str_contains($message, 'REQUEST: GET https://example.com'))
+        ->once()->andReturnSelf();
+    $logger->shouldReceive('info')
+        ->withArgs(fn ($message) => str_contains($message, 'RESPONSE: HTTP/1.1 200 OK'))
+        ->once()->andReturnSelf();
+
+    Http::fake()->get('https://example.com');
+});

--- a/tests/HttpClientLoggerTest.php
+++ b/tests/HttpClientLoggerTest.php
@@ -9,6 +9,10 @@ use Psr\Log\LoggerInterface;
 
 function setupLogger(): MockInterface
 {
+    // These cases assert the individual REQUEST/RESPONSE entries, so pin the legacy
+    // two-entry mode; the combined default is covered by CombinedLoggingTest.
+    config(['http-client-global-logger.combined' => false]);
+
     HttpClientLogger::addRequestMiddleware();
 
     $logger = Mockery::mock(LoggerInterface::class);


### PR DESCRIPTION
Fixes #7.

## Problem

Each HTTP call is logged as **two separate records** (`REQUEST:` on send, `RESPONSE:` on receive). Under concurrency — multiple workers/processes sharing the channel, or pooled/async requests — those two records get separated by other calls' records in the logfile, and since they carry no correlation id, a response can no longer be matched back to its request. (The writes themselves are atomic; the problem is purely correlation — see #7.)

## Change

Log each call as a **single combined record** — request + response together, emitted when the response arrives — instead of two separate records. The individual `REQUEST:` / `RESPONSE:` block format is **unchanged**; the two blocks are simply emitted as one log record, so every record is now a complete, self-contained call and interleaving is impossible.

This is the new **default**. A `combined` config flag (`HTTP_CLIENT_GLOBAL_LOGGER_COMBINED`, default `true`) restores the legacy two-record behaviour for anyone who relies on it.

### Implementation

- `LogResponseReceived` prepends the request message (reusing the existing `format.request`) when combined, producing one record.
- `LogRequestSending` skips its separate write when combined.
- Header obfuscation moved into a shared `ObfuscatesHeaders` trait (was private to `LogRequestSending`) so both listeners reuse it.
- New `combined` config option, documented in README + CHANGELOG.

### Compatibility

- No format change to the `REQUEST:` / `RESPONSE:` blocks — only how many records they're written in.
- Legacy behaviour fully available via `combined => false`.
- Existing tests pinned to `combined => false`; new `CombinedLoggingTest` covers the default and the opt-out. Full suite green (45 tests), Pint clean on changed files.

### Note

In combined mode the request is taken from the `ResponseReceived` event. If you use `HttpClientLogger::addRequestMiddleware()` specifically to capture the request *after* global request middleware, that nuance isn't reflected in the combined record — happy to extend this (e.g. stash the post-middleware request) if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
